### PR TITLE
DO NOT MERGE - Example Fake "new repository created" event for old repositories

### DIFF
--- a/handlers/fyiForRepoRequestedViaREST.js
+++ b/handlers/fyiForRepoRequestedViaREST.js
@@ -1,0 +1,35 @@
+const repoCreatedHandler = require('./repoCreated')
+const githubServices = require('../services/github')
+
+module.exports = (robot) => {
+  return (request, response) => {
+    const dataChunks = []
+    request.on('error', (error) => {
+      response.statusCode = 500
+      response.end(error.toString())
+    })
+
+    request.on('data', (chunk) => {
+      dataChunks.push(chunk)
+      console.log(chunk)
+    })
+    request.on('end', () => {
+      const payload = Buffer.concat(dataChunks).toString()
+      const data = JSON.parse(payload)
+      const context = require('../test/events/new-repo-created.json')
+      context.payload.repository.name = data.name
+      context.payload.repository.owner.login = data.org
+      context.payload.organization.login = data.org
+      context.payload.sender.login = data.sender
+      context.issue = (issueData) => {
+        let start = {number: undefined}
+        return Object.assign(start, issueData)
+      }
+
+      context.github = githubServices(robot, data.org)
+
+      repoCreatedHandler(context, robot)
+        .then( () => response.send(JSON.stringify({success: true})) ) 
+    })
+  }
+}

--- a/handlers/repoCreated.js
+++ b/handlers/repoCreated.js
@@ -1,0 +1,62 @@
+const configGH = require('config').github
+const configDB = require('config').database
+const filter = require('../middleware/filter')
+const reauth = require('../utils/reauth')
+const messaging = require('../messaging')
+const Event = require('../models').Event
+const Fyi = require('../models').Fyi
+
+module.exports = async (context, robot) => {
+  if (await filter('repository.created', context)) return
+
+  let { adminOrg, adminRepo, adminUsers } = configGH
+    // start - calculate probot metadata
+  const org = context.payload.organization.login
+  const repo = context.payload.repository.name
+  const repoCreator = context.payload.sender.login
+  const prefix = process.env.APP_ID
+  let data = {}
+  data[prefix] = {}
+  data[prefix]['type'] = 'fyi'
+  data[prefix]['org'] = org
+  data[prefix]['repo'] = repo
+  data[prefix]['repoCreator'] = repoCreator
+  let json = JSON.stringify(data)
+
+    // calculate labels for dev and stag
+  let labels = ['fyi-approval']
+  let environment = process.env.NODE_ENV || 'development'
+  let username = configDB.get('username')
+
+  if (environment === 'development') {
+    labels.push(`dev-${username}`)
+  } else if (environment === 'staging') {
+    labels.push(`stg`)
+  }
+
+  let body = messaging['approve-fyi-request']({
+    repo,
+    org,
+    repoCreator,
+    json
+  })
+    // create issue in Admin repo
+  let github = await reauth(robot, context, adminOrg)
+
+  await github.issues.create(context.issue({
+    owner: adminOrg,
+    repo: adminRepo,
+    title: `Approve FYI request for new repo: ${repo}`,
+    body,
+    labels,
+    assignees: adminUsers
+  }))
+
+    // add event to db
+  await Event.create({
+    github_project: repo,
+    system: repo,
+    event: Event.event_types['new_repo_created'],
+    actor: repoCreator
+  })
+}

--- a/index.js
+++ b/index.js
@@ -17,70 +17,19 @@ if (require.main === module) {
 
 const metadata = require('probot-metadata')
 const commands = require('probot-commands')
-const configGH = require('config').github
-const configDB = require('config').database
 const filter = require('./middleware/filter')
 const reauth = require('./utils/reauth')
 const messaging = require('./messaging')
 const Event = require('./models').Event
 const Fyi = require('./models').Fyi
+const repoCreatedHandler = require('./handlers/repoCreated')
+const fyiForRepoRequestedViaRESTHandler = require('./handlers/fyiForRepoRequestedViaREST')
 
 module.exports = robot => {
   robot.log('🤖  Arch Bot is listening...')
   robot.router.use(require('@condenast/express-dogstatsd')({}))
-  robot.on('repository.created', async context => {
-    if (await filter('repository.created', context)) return
-
-    let { adminOrg, adminRepo, adminUsers } = configGH
-    // start - calculate probot metadata
-    const org = context.payload.organization.login
-    const repo = context.payload.repository.name
-    const repoCreator = context.payload.sender.login
-    const prefix = process.env.APP_ID
-    let data = {}
-    data[prefix] = {}
-    data[prefix]['type'] = 'fyi'
-    data[prefix]['org'] = org
-    data[prefix]['repo'] = repo
-    data[prefix]['repoCreator'] = repoCreator
-    let json = JSON.stringify(data)
-
-    // calculate labels for dev and stag
-    let labels = ['fyi-approval']
-    let environment = process.env.NODE_ENV || 'development'
-    let username = configDB.get('username')
-
-    if (environment === 'development') {
-      labels.push(`dev-${username}`)
-    } else if (environment === 'staging') {
-      labels.push(`stg`)
-    }
-
-    let body = messaging['approve-fyi-request']({
-      repo,
-      org,
-      repoCreator,
-      json
-    })
-    // create issue in Admin repo
-    let github = await reauth(robot, context, adminOrg)
-    await github.issues.create(context.issue({
-      owner: adminOrg,
-      repo: adminRepo,
-      title: `Approve FYI request for new repo: ${repo}`,
-      body,
-      labels,
-      assignees: adminUsers
-    }))
-
-    // add event to db
-    await Event.create({
-      github_project: repo,
-      system: repo,
-      event: Event.event_types['new_repo_created'],
-      actor: repoCreator
-    })
-  })
+  robot.router.post('/repo', fyiForRepoRequestedViaRESTHandler(robot))
+  robot.on('repository.created', (context) => repoCreatedHandler(context, robot))
 
   commands(robot, 'approve', async (context, command) => {
     if (await filter('approve', context)) return

--- a/services/github.js
+++ b/services/github.js
@@ -1,0 +1,11 @@
+module.exports = async (robot, targetOrg) => {
+  let github = await robot.auth()
+  const installation = await github.request({
+    method: 'GET',
+    url: '/orgs/:org/installation',
+    headers: { accept: 'application/vnd.github.machine-man-preview+json' },
+    org: targetOrg
+  })
+  github = await robot.auth(installation.data.id)
+  return github
+}


### PR DESCRIPTION
DO NOT MERGE

This is for exemplary purposes only. 

This is a proof of concept around creating a fake event and triggering the same logic for old and new repositories. 

